### PR TITLE
Make wisps placement around the player more natural

### DIFF
--- a/Assets/Scripts/AttackWisp.cs
+++ b/Assets/Scripts/AttackWisp.cs
@@ -18,7 +18,7 @@ public class AttackWisp : Wisp
 
     protected override IEnumerator OnActivate()
     {
-        return SmoothMovement((Vector2)playerObject.transform.position + Player().AimedDirection() * range);
+        return MoveToTarget((Vector2)playerObject.transform.position + Player().AimedDirection() * range);
     }
 
     protected override IEnumerator OnDetach()

--- a/Assets/Scripts/AttackWisp.cs
+++ b/Assets/Scripts/AttackWisp.cs
@@ -6,6 +6,16 @@ public class AttackWisp : Wisp
 {
     public float range = 5;
 
+    void Start()
+    {
+        color = new Color(
+            Random.Range(0.4f, 1f),
+            Random.Range(0.4f, 1f),
+            Random.Range(0.4f, 1f)
+        );
+        ResetColor();
+    }
+
     protected override IEnumerator OnActivate()
     {
         return SmoothMovement((Vector2)playerObject.transform.position + Player().AimedDirection() * range);

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -125,6 +125,6 @@ public class BoardManager : MonoBehaviour
     {
         // Debug new wisp
         if (Input.GetKeyDown(KeyCode.Q))
-            player.AddWisp(Instantiate(wisps[Random.Range(0, wisps.Length)], null));
+            player.AddWisp(Instantiate(wisps[Random.Range(0, wisps.Length)], player.transform.position, Quaternion.identity, null));
     }
 }

--- a/Assets/Scripts/MovingObject.cs
+++ b/Assets/Scripts/MovingObject.cs
@@ -1,0 +1,109 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MovingObject : MonoBehaviour
+{
+    private struct Target
+    {
+        public Vector2 position;
+        public bool local;
+
+        public Target(Vector2 position, bool local = false)
+        {
+            this.position = position;
+            this.local = local;
+        }
+    }
+
+    public float moveSpeed = 10;
+    private List<Target> targets;
+
+    public void Awake()
+    {
+        targets = new();
+    }
+
+    protected virtual void Update()
+    {
+        MoveTowardsTarget();
+    }
+
+    public bool IsMoving()
+    {
+        return targets.Count > 0;
+    }
+
+    /// Returns the current target
+    // Warning: Will raise Out of range error if no target is left
+    private Target GetTarget()
+    {
+        return targets[0];
+    }
+
+    // Delete all the targets and set a new one
+    public void SetTarget(Vector2 target, bool local = false)
+    {
+        targets.Clear();
+        targets.Add(new Target(target, local));
+    }
+
+    // Add a new target in the list
+    public void AddTarget(Vector2 target, bool local = false)
+    {
+        targets.Add(new Target(target, local));
+    }
+
+    // Delete the current target if any
+    public void PopCurrentTarget()
+    {
+        if (IsMoving())
+            targets.RemoveAt(0);
+    }
+
+    // Move toward the current target if any.
+    // Return true if the object position changed.
+    public bool MoveTowardsTarget()
+    {
+        // Be sure to have a target
+        if (!IsMoving())
+            return false;
+
+        Target target = GetTarget();
+        float sqrRemainingDistance = ((Vector2)(target.local ? transform.localPosition : transform.position) - target.position).sqrMagnitude;
+
+        // We reached this target
+        if (sqrRemainingDistance < float.Epsilon)
+        {
+            // Pop this target and try to move to the next one (if any)
+            PopCurrentTarget();
+            return MoveTowardsTarget();
+        }
+
+        // Move towards the target
+        if (target.local)
+            transform.localPosition = Vector3.MoveTowards(transform.localPosition, target.position, moveSpeed * Time.deltaTime);
+        else
+            transform.position = Vector3.MoveTowards(transform.position, target.position, moveSpeed * Time.deltaTime);
+        return true;
+    }
+
+    public bool MoveTowardsTarget(Vector2 target, bool local = false)
+    {
+        SetTarget(target, local);
+        return MoveTowardsTarget();
+    }
+
+    protected IEnumerator MoveToTarget()
+    {
+        while (MoveTowardsTarget())
+            yield return null;
+    }
+
+    protected IEnumerator MoveToTarget(Vector2 target, bool local = false)
+    {
+        SetTarget(target, local);
+        while (MoveTowardsTarget())
+            yield return null;
+    }
+}

--- a/Assets/Scripts/MovingObject.cs.meta
+++ b/Assets/Scripts/MovingObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e420827fca1f4bd4c97a8b0c395a4b78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Wisp.cs
+++ b/Assets/Scripts/Wisp.cs
@@ -47,7 +47,7 @@ public abstract class Wisp : MonoBehaviour
         return owningWispsGroup != null;
     }
 
-    void ResetColor()
+    protected void ResetColor()
     {
         // Wisp is in detached mode
         if (IsDetached())

--- a/Assets/Scripts/Wisp.cs
+++ b/Assets/Scripts/Wisp.cs
@@ -2,12 +2,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class Wisp : MonoBehaviour
+public abstract class Wisp : MovingObject
 {
     public GameObject playerObject;
     public Color color;
     public Color disabledColor;
-    public float moveSpeed = 20;
 
 
     // The cooldown time, in seconds
@@ -24,8 +23,9 @@ public abstract class Wisp : MonoBehaviour
     }
 
     // Update is called once per frame
-    void Update()
+    protected override void Update()
     {
+        base.Update();
         if (currentCooldown > float.Epsilon)
         {
             currentCooldown -= Time.deltaTime;
@@ -102,28 +102,9 @@ public abstract class Wisp : MonoBehaviour
 
     protected abstract IEnumerator OnAttach();
 
-    protected bool MoveTowardsPoint(Vector2 point)
-    {
-        float sqrRemainingDistance = ((Vector2)transform.position - point).sqrMagnitude;
-
-        // No need to move
-        if (sqrRemainingDistance < float.Epsilon)
-            return false;
-
-        // Move towards the point
-        transform.position = Vector3.MoveTowards(transform.position, point, moveSpeed * Time.deltaTime);
-        return true;
-    }
-
-    protected IEnumerator SmoothMovement(Vector3 end)
-    {
-        while (MoveTowardsPoint(end))
-            yield return null;
-    }
-
     protected IEnumerator ReturnToPlayer()
     {
-        while (MoveTowardsPoint((Vector2)playerObject.transform.position - ((Vector2)(playerObject.transform.position - transform.position)).normalized * owningWispsGroup.GetComponent<WispsGroup>().orbitDistance))
+        while (MoveTowardsTarget((Vector2)playerObject.transform.position - ((Vector2)(playerObject.transform.position - transform.position)).normalized * owningWispsGroup.GetComponent<WispsGroup>().orbitDistance))
             yield return null;
     }
 }

--- a/Assets/Scripts/WispsGroup.cs
+++ b/Assets/Scripts/WispsGroup.cs
@@ -33,9 +33,9 @@ public class WispsGroup : MonoBehaviour
 
         float startingAngle = Vector2.SignedAngle(Vector2.down, wisps[wispIndex].transform.localPosition);
         for (int i = wispIndex; i >= 0; i--)
-            wisps[i].transform.localPosition = Quaternion.AngleAxis(startingAngle - gap * (wispIndex - i), Vector3.forward) * Vector2.down * orbitDistance;
+            wisps[i].GetComponent<Wisp>().SetTarget(Quaternion.AngleAxis(startingAngle - gap * (wispIndex - i), Vector3.forward) * Vector2.down * orbitDistance, true);
         for (int i = wispIndex + 1; i < wisps.Count; i++)
-            wisps[i].transform.localPosition = Quaternion.AngleAxis(startingAngle + gap * (i - wispIndex), Vector3.forward) * Vector2.down * orbitDistance;
+            wisps[i].GetComponent<Wisp>().SetTarget(Quaternion.AngleAxis(startingAngle + gap * (i - wispIndex), Vector3.forward) * Vector2.down * orbitDistance, true);
     }
 
     private float GetWispAngle(GameObject wisp)
@@ -53,7 +53,12 @@ public class WispsGroup : MonoBehaviour
         if (wisps.Count == 0)
             wispIndex = wisps.Count;
         else
-            wispIndex = (int)(GetWispAngle(wisp) / (360f / wisps.Count)) + 1;
+        {
+            float angle = GetWispAngle(wisp) - GetWispAngle(wisps[0]);
+            if (angle < 0)
+                angle += 360;
+            wispIndex = (int)(angle / (360f / wisps.Count)) + 1;
+        }
 
         // Append wisp at the end
         if (wispIndex == wisps.Count)


### PR DESCRIPTION
# Description

When a wisps is added to the player, it takes the closest place in the wisps group. All other wisps are pushed around to keep an equalized gap between each wisp. Moreover the wisps placement is made smoothly using the new base class MovingObject.

The MovingObject allows to set target positions to object. It supports sequential targets (target list, reached one by one) as well as single one. Targets are defined in global space by default but almost all methods supports a second optionnal parameter `local` which, if set to true, will handle the target in local space.

This PR mostly makes visual changes. The Attack Wisps now have a random color for a better visualisation of the different wisps' placements. This random color must be removed when the effective assets will be applied.

Close #37

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Minor fixes

The debug action of creating a new wisp now instantiate them at the player position.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
