### PR TITLE
Separate selected wisp from the wisp group orbit

### DIFF
--- a/Assets/Prefabs/Wisps/WispsGroup.prefab
+++ b/Assets/Prefabs/Wisps/WispsGroup.prefab
@@ -46,4 +46,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   orbitSpeed: 10
   orbitDistance: 1.5
-  selectedWispIndex: -1
+  selectedOrbitDistance: 0.8

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -467,7 +467,7 @@ MonoBehaviour:
   m_BlendStyleIndex: 0
   m_FalloffIntensity: 0.5
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 0.5
+  m_Intensity: 0.15
   m_LightVolumeIntensity: 1
   m_LightVolumeIntensityEnabled: 0
   m_ApplyToSortingLayers: 00000000a17c14dddfb69217811f5319514f796a

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -125,6 +125,6 @@ public class BoardManager : MonoBehaviour
     {
         // Debug new wisp
         if (Input.GetKeyDown(KeyCode.Q))
-            player.AddWisp(Instantiate(wisps[Random.Range(0, wisps.Length)], player.transform.position, Quaternion.identity, null));
+            player.AddWisp(Instantiate(wisps[Random.Range(0, wisps.Length)], player.transform.position, Quaternion.identity, null).GetComponent<Wisp>());
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -39,7 +39,7 @@ public class Player : MonoBehaviour
          Attack();
    }
 
-   WispsGroup GetWisps()
+   public WispsGroup GetWisps()
    {
       return gameObject.GetComponentInChildren<WispsGroup>();
    }
@@ -61,10 +61,10 @@ public class Player : MonoBehaviour
       return ((Vector2)Camera.main.ScreenToWorldPoint(Input.mousePosition) - (Vector2)transform.position).normalized;
    }
 
-   public void AddWisp(GameObject wispObject)
+   public void AddWisp(Wisp wisp)
    {
-      wispObject.GetComponent<Wisp>().playerObject = gameObject;
-      GetWisps().AddWisp(wispObject);
+      wisp.playerObject = gameObject;
+      GetWisps().AddWisp(wisp);
    }
 
    private void Attack()

--- a/Assets/Scripts/Wisp.cs
+++ b/Assets/Scripts/Wisp.cs
@@ -26,7 +26,7 @@ public abstract class Wisp : MovingObject
     // The time remaining before the wisp can be activated
     private float currentCooldown = 0;
 
-    protected GameObject owningWispsGroup = null;
+    protected WispsGroup owningWispsGroup = null;
 
     // Start is called before the first frame update
     void Start()
@@ -77,14 +77,14 @@ public abstract class Wisp : MovingObject
 
     private IEnumerator Detach()
     {
-        owningWispsGroup = gameObject.transform.parent.gameObject;
-        owningWispsGroup.GetComponent<WispsGroup>().DetachWisp(gameObject);
+        owningWispsGroup = gameObject.transform.GetComponentInParent<Player>().GetWisps();
+        owningWispsGroup.DetachWisp(this);
         yield return StartCoroutine(OnDetach());
     }
 
     private IEnumerator Attach()
     {
-        owningWispsGroup.GetComponent<WispsGroup>().AddWisp(gameObject);
+        owningWispsGroup.AddWisp(this);
         owningWispsGroup = null;
         yield return StartCoroutine(OnAttach());
     }


### PR DESCRIPTION
# Description

The selected wisp is now closer to the player than the other wisps and it follows the player aiming direction.

Close #43

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Minor fixes

Store `Wisp` variables instead of `GameObject` in the `WispsGroup` class.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
