### PR TITLE
Add damage management for the player and wisp

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 2441727123651177938}
   m_Layer: 8
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -79,7 +79,10 @@ MonoBehaviour:
   enemyLayers:
     serializedVersion: 2
     m_Bits: 512
+  gameManager: {fileID: 6366123417487268299, guid: 3eeac57e8d5aa4e2ebcf1d51456cf58d, type: 3}
+  playerHp: 10
   runSpeed: 10
+  invisibleCoolDown: 1.5
   wispsGroupPrefab: {fileID: 1522740308722967485, guid: a9ec15806e6fc8f40bca3d60cfba797f, type: 3}
 --- !u!212 &5970868291076065725
 SpriteRenderer:

--- a/Assets/Scripts/Dummy.cs
+++ b/Assets/Scripts/Dummy.cs
@@ -6,7 +6,7 @@ public class Dummy : MonoBehaviour
 {   
     
     public float hp = 10;
-    
+
     public void getDamage(float damage)
     {
         hp -= damage;
@@ -23,5 +23,10 @@ public class Dummy : MonoBehaviour
     void ResetColor()
     {
       GetComponent<SpriteRenderer>().color = Color.white;
+    }
+
+    private void OnTriggerStay2D(Collider2D other) {
+        if (other.tag == "Player")
+            other.GetComponent<Player>().GetDamage();
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -38,4 +38,9 @@ public class GameManager : MonoBehaviour
     {
 
     }
+
+    public void GameOver()
+    {
+        Debug.Log("Game Over");
+    }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -5,16 +5,16 @@ using UnityEngine;
 public class Player : MonoBehaviour
 {
    [SerializeField] private LayerMask enemyLayers;
-
+   [SerializeField] private GameManager gameManager;
    Rigidbody2D body;
-
+  
    float horizontal;
    float vertical;
    float moveLimiter = 0.7f;
-
    public float runSpeed = 10.0f;
+   public float invisibleCoolDown = 2.0f;
+   float invisibleCurrentCoolDown = 0.0f;
    public GameObject wispsGroupPrefab;
-
    private Weapon weapon;
 
    private void Awake()
@@ -37,6 +37,10 @@ public class Player : MonoBehaviour
 
       if (Input.GetButtonDown("Attack"))
          Attack();
+      
+      if(invisibleCurrentCoolDown >= float.Epsilon)
+         invisibleCurrentCoolDown -= Time.deltaTime;
+      
    }
 
    public WispsGroup GetWisps()
@@ -74,5 +78,18 @@ public class Player : MonoBehaviour
          StartCoroutine(wisp.Activate());
       else
          gameObject.GetComponentInChildren<Weapon>().Attack();
+   }
+
+   public void GetDamage(){
+      if (invisibleCurrentCoolDown > float.Epsilon)
+         return;
+      Wisp wisp = GetWisps().GetSelectedWisp();
+      invisibleCurrentCoolDown = invisibleCoolDown;
+      if (wisp != null){
+         GetWisps().DetachWisp(wisp);
+         Destroy(wisp.gameObject);
+      }
+      else
+         gameManager.GameOver();
    }
 }


### PR DESCRIPTION
# Description

Add damage management to the player a wisp take damage first, when the player has no wisp, he simply dies. 

Close #46 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
