### PR TITLE
Introduce Pathfinding using NavMeshPlus package

### DIFF
--- a/Assets/Prefabs/Enemies/Dummy.prefab
+++ b/Assets/Prefabs/Enemies/Dummy.prefab
@@ -13,6 +13,8 @@ GameObject:
   - component: {fileID: 344452906587162988}
   - component: {fileID: 6777887900181523603}
   - component: {fileID: 2906092090025682062}
+  - component: {fileID: 2023089955221526479}
+  - component: {fileID: 4850594674959984824}
   m_Layer: 9
   m_Name: Dummy
   m_TagString: Enemy
@@ -48,6 +50,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hp: 10
+  target: {fileID: 0}
 --- !u!212 &344452906587162988
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -172,3 +175,37 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &2023089955221526479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6285399730554940182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e39f6090724e4a4a8aadeb042afa2bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!195 &4850594674959984824
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6285399730554940182}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.3
+  m_Speed: 3.5
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 1
+  m_BaseOffset: 0.5
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4

--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -73,3 +73,4 @@ MonoBehaviour:
   - {fileID: 8281400056468518210, guid: 33dde5e59ab92c7469c5d74b5f101738, type: 3}
   - {fileID: 5846959578341104856, guid: ffc40f52d391baf459575ea7ad0c17df, type: 3}
   playerPrefab: {fileID: 4740647157137170677, guid: 2d0117e30a4e7ad499133c85ff18cef6, type: 3}
+  navMeshSurface: {fileID: 7496402137135331960, guid: f0b8ad2ac8a21fd4e9b73ccda9dc62ba, type: 3}

--- a/Assets/Prefabs/Tiles/Floor.prefab
+++ b/Assets/Prefabs/Tiles/Floor.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1221145262882625230}
   - component: {fileID: 4576409004759743691}
+  - component: {fileID: -1667919725066350425}
   m_Layer: 0
   m_Name: Floor
   m_TagString: Untagged
@@ -84,3 +85,19 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &-1667919725066350425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457957571952232914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9809bf1345abc5648af68b3a82653f08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideArea: 1
+  m_Area: 0
+  m_IgnoreFromBuild: 0
+  m_AffectedAgents: ffffffff

--- a/Assets/Prefabs/Tiles/NavMesh.prefab
+++ b/Assets/Prefabs/Tiles/NavMesh.prefab
@@ -1,0 +1,108 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &455689976070694536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6853370231137017218}
+  - component: {fileID: 7496402137135331960}
+  - component: {fileID: 8882036880659397998}
+  - component: {fileID: 758896931095554892}
+  - component: {fileID: 1121824212704598234}
+  m_Layer: 0
+  m_Name: NavMesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6853370231137017218
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 455689976070694536}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7496402137135331960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 455689976070694536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e04976799df50f54ba128eff723155a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AgentTypeID: 0
+  m_CollectObjects: 2
+  m_Size: {x: 10, y: 10, z: 10}
+  m_Center: {x: 0, y: 2, z: 0}
+  m_LayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_UseGeometry: 0
+  m_DefaultArea: 0
+  m_IgnoreNavMeshAgent: 1
+  m_IgnoreNavMeshObstacle: 1
+  m_OverrideTileSize: 1
+  m_TileSize: 128
+  m_OverrideVoxelSize: 0
+  m_VoxelSize: 0.13333334
+  m_BuildHeightMesh: 0
+  m_HideEditorLogs: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!114 &8882036880659397998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 455689976070694536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70bd44a44cd62c64fbfc1eea95b24880, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideByGrid: 0
+  m_UseMeshPrefab: {fileID: 0}
+  m_CompressBounds: 0
+  m_OverrideVector: {x: 1, y: 1, z: 1}
+--- !u!114 &758896931095554892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 455689976070694536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec7b7904f76c4498a68fd145934563, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rootSources: []
+--- !u!114 &1121824212704598234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 455689976070694536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5492b7ed96378624cbcd72212fce093d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Tiles/NavMesh.prefab.meta
+++ b/Assets/Prefabs/Tiles/NavMesh.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f0b8ad2ac8a21fd4e9b73ccda9dc62ba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tiles/Wall.prefab
+++ b/Assets/Prefabs/Tiles/Wall.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 4611537252771574780}
   - component: {fileID: -8083351822675837085}
   - component: {fileID: -2801834624498637751}
+  - component: {fileID: 1596502020982415036}
   m_Layer: 8
   m_Name: Wall
   m_TagString: Wall
@@ -189,3 +190,19 @@ MonoBehaviour:
   m_LocalBounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0.5, y: 0.5, z: 0}
+--- !u!114 &1596502020982415036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6765124784350681279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9809bf1345abc5648af68b3a82653f08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideArea: 1
+  m_Area: 1
+  m_IgnoreFromBuild: 0
+  m_AffectedAgents: ffffffff

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -136,6 +136,7 @@ GameObject:
   - component: {fileID: 856513515}
   - component: {fileID: 856513518}
   - component: {fileID: 856513519}
+  - component: {fileID: 856513520}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -264,6 +265,50 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &856513520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 856513514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
 --- !u!1 &1694794761
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -1,7 +1,12 @@
 using System.Collections.Generic;
 using Cinemachine;
+using NavMeshPlus.Components;
+using NavMeshPlus.Extensions;
+using UnityEditor.Build.Content;
 using UnityEngine;
+using UnityEngine.AI;
 using Random = UnityEngine.Random;
+
 
 public class BoardManager : MonoBehaviour
 {
@@ -17,6 +22,7 @@ public class BoardManager : MonoBehaviour
     public GameObject enemy;
     public GameObject[] wisps;
     public Player playerPrefab;
+    public NavMeshSurface navMeshSurface;
 
     private Player player;
     private Transform boardHolder;
@@ -48,9 +54,7 @@ public class BoardManager : MonoBehaviour
                 {
                     toInstantiate = outerWallTiles[Random.Range(0, outerWallTiles.Length)];
                 }
-                GameObject instance = Instantiate(toInstantiate, new Vector3(x, y, 0f), Quaternion.identity) as GameObject;
-
-                instance.transform.SetParent(boardHolder);
+                Instantiate(toInstantiate, new Vector3(x, y, 0f), Quaternion.identity, boardHolder);
             }
         }
     }
@@ -80,7 +84,7 @@ public class BoardManager : MonoBehaviour
         {
             Vector3 randomPosition = RandomPosition();
             GameObject tileChoice = tileArray[Random.Range(0, tileArray.Length)];
-            Instantiate(tileChoice, randomPosition, Quaternion.identity);
+            Instantiate(tileChoice, randomPosition, Quaternion.identity, boardHolder);
         }
     }
 
@@ -89,7 +93,7 @@ public class BoardManager : MonoBehaviour
         for (int i = 0; i < enemiesCount; i++)
         {
             Vector3 randomPosition = RandomPosition();
-            Instantiate(enemy, randomPosition, Quaternion.identity);
+            Instantiate(enemy, randomPosition, Quaternion.identity).GetComponent<Dummy>().target = player.gameObject;
         }
     }
 
@@ -103,14 +107,22 @@ public class BoardManager : MonoBehaviour
         vcam.Follow = player.transform;
     }
 
+    void BuildNavMesh()
+    {
+        NavMeshSurface navMeshInstance = Instantiate(navMeshSurface);
+        navMeshInstance.GetComponent<RootSources2d>().RooySources.Add(boardHolder.gameObject);
+        navMeshInstance.BuildNavMesh();
+    }
+
     public void SetupScene()
     {
         BoardSetup();
         InitialiseList();
         LayoutObjectAtRandom(wallTiles);
-        LayoutEnemiesAtRandom(enemy);
         LayoutPlayer(playerPrefab);
+        LayoutEnemiesAtRandom(enemy);
         SetupCameraBoundaries();
+        BuildNavMesh();
     }
 
     // Start is called before the first frame update

--- a/Assets/Scripts/Dummy.cs
+++ b/Assets/Scripts/Dummy.cs
@@ -1,10 +1,23 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.AI;
 
 public class Dummy : MonoBehaviour
 {
     public float hp = 10;
+    public GameObject target;
+    private NavMeshAgent agent;
+
+    void Start()
+    {
+        agent = GetComponent<NavMeshAgent>();
+    }
+
+    void Update()
+    {
+        agent.SetDestination(target.transform.position);
+    }
 
     public void getDamage(float damage)
     {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "com.h8man.2d.navmeshplus": "https://github.com/h8man/NavMeshPlus.git",
+    "com.unity.ai.navigation": "1.1.4",
     "com.unity.cinemachine": "2.9.7",
     "com.unity.collab-proxy": "2.0.4",
     "com.unity.feature.2d": "2.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.h8man.2d.navmeshplus": {
+      "version": "https://github.com/h8man/NavMeshPlus.git",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "4f4966ff65ec4ca4dbe76fdbefcef9e89d009375"
+    },
     "com.unity.2d.animation": {
       "version": "9.0.3",
       "depth": 1,
@@ -91,6 +98,15 @@
         "com.unity.2d.tilemap": "1.0.0",
         "com.unity.ugui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ai.navigation": {
+      "version": "1.1.4",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.ai": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },

--- a/ProjectSettings/NavMeshAreas.asset
+++ b/ProjectSettings/NavMeshAreas.asset
@@ -71,9 +71,9 @@ NavMeshProjectSettings:
     cost: 1
   m_LastAgentTypeID: -887442657
   m_Settings:
-  - serializedVersion: 2
+  - serializedVersion: 3
     agentTypeID: 0
-    agentRadius: 0.5
+    agentRadius: 0.3
     agentHeight: 2
     agentSlope: 45
     agentClimb: 0.75
@@ -84,7 +84,7 @@ NavMeshProjectSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:


### PR DESCRIPTION
# Description

Introduce pathfinding functionnality for dummy enemy. It is now following the player around the room.

Add 2 new dependencies:
- Unity AI Navigation: used for 3d pathfinding through navigation mesh
- NavMeshPlus: Allows to easily use Unity AI Navigation in 2D environment (https://github.com/h8man/NavMeshPlus)

Close #14

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Minor fixes

All walls/floors are childs of the "Board" game object.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
