### PR TITLE
Implement wisp selection (previous/next)

### DIFF
--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -123,7 +123,7 @@ public class BoardManager : MonoBehaviour
     void Update()
     {
         // Debug new wisp
-        if (Input.GetKeyDown(KeyCode.Q))
+        if (Input.GetKeyDown(KeyCode.T))
             player.AddWisp(Instantiate(wisps[Random.Range(0, wisps.Length)], player.transform.position, Quaternion.identity, null).GetComponent<Wisp>());
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -38,6 +38,11 @@ public class Player : MonoBehaviour
         if (Input.GetButtonDown("Attack"))
             Attack();
 
+        if (Input.GetButtonDown("SelectNextWisp"))
+            GetWisps().SelectNextWisp();
+        if (Input.GetButtonDown("SelectPreviousWisp"))
+            GetWisps().SelectPreviousWisp();
+
         if (invisibleCurrentCoolDown >= float.Epsilon)
             invisibleCurrentCoolDown -= Time.deltaTime;
     }

--- a/Assets/Scripts/WispsGroup.cs
+++ b/Assets/Scripts/WispsGroup.cs
@@ -119,4 +119,32 @@ public class WispsGroup : MonoBehaviour
     {
         return selectedWisp;
     }
+
+    public void SelectNextWisp()
+    {
+        if (selectedWisp == null || wisps.Count == 0)
+            return;
+        // Get the selected wisp back into the group
+        selectedWisp.transform.SetParent(transform);
+        wisps.Add(selectedWisp);
+        // Select the next wisp
+        selectedWisp = wisps[0];
+        wisps.RemoveAt(0);
+        // Equalize the orbiting wisps positions
+        EqualizeWisps(wisps.Count - 1);
+    }
+
+    public void SelectPreviousWisp()
+    {
+        if (selectedWisp == null || wisps.Count == 0)
+            return;
+        // Get the selected wisp back into the group
+        selectedWisp.transform.SetParent(transform);
+        wisps.Insert(0, selectedWisp);
+        // Select the previous wisp
+        selectedWisp = wisps[^1];
+        wisps.RemoveAt(wisps.Count - 1);
+        // Equalize the orbiting wisps positions
+        EqualizeWisps(0);
+    }
 }


### PR DESCRIPTION
# Description

Implement wisp selection. You can select the next wisp with E end the previous with A (azerty keyboard).

Close #32

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Minor fixes

Moved the debug "New wisp" key to T.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
