### PR TITLE
Don't select non activable wisps if other are activable && Introduce weapon only mode

### DIFF
--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -15,6 +15,7 @@ public class Player : Singleton<Player>
     public float invisibleCoolDown = 2.0f;
     float invisibleCurrentCoolDown = 0.0f;
     public GameObject wispsGroupPrefab;
+    private bool onlyWeaponAttack = false;
     private Weapon weapon;
 
     protected override void Awake()
@@ -34,6 +35,8 @@ public class Player : Singleton<Player>
 
         if (Input.GetButtonDown("Attack"))
             Attack();
+        if (Input.GetButtonDown("ToggleWeaponMode"))
+            ToggleWeaponMode();
 
         if (Input.GetButtonDown("SelectNextWisp"))
             GetWisps().SelectNextWisp();
@@ -42,6 +45,11 @@ public class Player : Singleton<Player>
 
         if (invisibleCurrentCoolDown >= float.Epsilon)
             invisibleCurrentCoolDown -= Time.deltaTime;
+    }
+
+    public void ToggleWeaponMode()
+    {
+        onlyWeaponAttack = !onlyWeaponAttack;
     }
 
     public WispsGroup GetWisps()
@@ -75,7 +83,7 @@ public class Player : Singleton<Player>
     private void Attack()
     {
         Wisp wisp = GetWisps().GetSelectedWisp();
-        if (wisp != null)
+        if (!onlyWeaponAttack && wisp != null && wisp.IsActivable())
             StartCoroutine(wisp.Activate());
         else
             gameObject.GetComponentInChildren<Weapon>().Attack();

--- a/Assets/Scripts/WispsGroup.cs
+++ b/Assets/Scripts/WispsGroup.cs
@@ -94,14 +94,32 @@ public class WispsGroup : MonoBehaviour
             InsertWispNaturally(wisp);
     }
 
+    private int GetNextActivableWispIndex(int defaultIndex = -1)
+    {
+        for (int i = 0; i < wisps.Count; i++)
+            if (wisps[i].IsActivable())
+                return i;
+        return defaultIndex;
+    }
+
+    private int GetPreviousActivableWispIndex(int defaultIndex = -1)
+    {
+        for (int i = wisps.Count - 1; i >= 0; i--)
+            if (wisps[i].IsActivable())
+                return i;
+        return defaultIndex;
+    }
+
     public void DetachSelectedWisp()
     {
         if (wisps.Count == 0)
             selectedWisp = null;
         else
         {
-            selectedWisp = wisps[0];
-            wisps.RemoveAt(0);
+            // Get the next activable wisp if any, or the next one if they are all in cooldown
+            int wispIndex = GetNextActivableWispIndex(0);
+            selectedWisp = wisps[wispIndex];
+            wisps.RemoveAt(wispIndex);
         }
     }
 
@@ -124,27 +142,38 @@ public class WispsGroup : MonoBehaviour
     {
         if (selectedWisp == null || wisps.Count == 0)
             return;
-        // Get the selected wisp back into the group
-        selectedWisp.transform.SetParent(transform);
-        wisps.Add(selectedWisp);
-        // Select the next wisp
-        selectedWisp = wisps[0];
-        wisps.RemoveAt(0);
-        // Equalize the orbiting wisps positions
-        EqualizeWisps(wisps.Count - 1);
+        int wispIndex = GetNextActivableWispIndex(0);
+
+        for (int i = 0; i < wispIndex + 1; i++)
+        {
+            // Get the selected wisp back into the group
+            selectedWisp.transform.SetParent(transform);
+            wisps.Add(selectedWisp);
+            // Select the next wisp
+            selectedWisp = wisps[0];
+            wisps.RemoveAt(0);
+
+            // Equalize the orbiting wisps positions
+            EqualizeWisps(wisps.Count - 1);
+        }
     }
 
     public void SelectPreviousWisp()
     {
         if (selectedWisp == null || wisps.Count == 0)
             return;
-        // Get the selected wisp back into the group
-        selectedWisp.transform.SetParent(transform);
-        wisps.Insert(0, selectedWisp);
-        // Select the previous wisp
-        selectedWisp = wisps[^1];
-        wisps.RemoveAt(wisps.Count - 1);
-        // Equalize the orbiting wisps positions
-        EqualizeWisps(0);
+        int wispIndex = GetPreviousActivableWispIndex(wisps.Count - 1);
+
+        for (int i = wisps.Count - 1; i >= wispIndex; i--)
+        {
+            // Get the selected wisp back into the group
+            selectedWisp.transform.SetParent(transform);
+            wisps.Insert(0, selectedWisp);
+            // Select the previous wisp
+            selectedWisp = wisps[^1];
+            wisps.RemoveAt(wisps.Count - 1);
+            // Equalize the orbiting wisps positions
+            EqualizeWisps(0);
+        }
     }
 }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -54,6 +54,22 @@ InputManager:
     axis: 0
     joyNum: 0
   - serializedVersion: 3
+    m_Name: ToggleWeaponMode
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: left ctrl
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
     m_Name: SecondaryAttack
     descriptiveName: 
     descriptiveNegativeName: 


### PR DESCRIPTION
# Description

When selecting previous/next wisp, all non activable wisps are skipped (if there is at least one activable).
When the player has a non activable wisp, the weapon is used when attacking.

A new weapon only mode has been introduced and is toggled by the left control key. When this mode is activated, the player doesn't use the wisps anymore.

Close #63 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
