### PR TITLE
Wisp stack

### DIFF
--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -59,6 +59,8 @@ MonoBehaviour:
   wisps:
   - {fileID: 9030161684494959953, guid: 33dde5e59ab92c7469c5d74b5f101738, type: 3}
   - {fileID: 6865338212822090350, guid: ffc40f52d391baf459575ea7ad0c17df, type: 3}
+  - {fileID: 211061251685254441, guid: f23e9920d57873a4082c775ff8f0daed, type: 3}
+  - {fileID: 4472103200368369339, guid: 725140852f888f84d81d4a58cbfc2ce4, type: 3}
   player: {fileID: 4740647157137170677, guid: 2d0117e30a4e7ad499133c85ff18cef6, type: 3}
   companion: {fileID: 3206609104498396570, guid: 5315728c7a4ae3e4c9a9af85af6bb4db, type: 3}
   wispsGroup: {fileID: 2556091340606255187, guid: a9ec15806e6fc8f40bca3d60cfba797f, type: 3}

--- a/Assets/Prefabs/Wisps/AttackWisp.prefab
+++ b/Assets/Prefabs/Wisps/AttackWisp.prefab
@@ -58,6 +58,7 @@ MonoBehaviour:
   speedMultiplier: 20
   damageMultiplier: 1
   cooldownTime: 0.5
+  owningWispsGroup: {fileID: 0}
   damageBoost: 0.3
 --- !u!58 &6151515475814858440
 CircleCollider2D:

--- a/Assets/Prefabs/Wisps/BombWisp.prefab
+++ b/Assets/Prefabs/Wisps/BombWisp.prefab
@@ -59,10 +59,11 @@ MonoBehaviour:
   damageMultiplier: 1
   cooldownTime: 1
   owningWispsGroup: {fileID: 0}
+  explosionMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
   explosionDamage: 10
-  radiusExplosion: 15
-  explosionDuration: 0.1
-  currentExplosionDuration: 0
+  explosionRadius: 2
 --- !u!58 &7561967548908028700
 CircleCollider2D:
   m_ObjectHideFlags: 0
@@ -88,7 +89,7 @@ CircleCollider2D:
     m_Bits: 4294967295
   m_ContactCaptureLayers:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 768
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295

--- a/Assets/Prefabs/Wisps/PoisonWisp.prefab
+++ b/Assets/Prefabs/Wisps/PoisonWisp.prefab
@@ -76,7 +76,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 424877953
   m_SortingLayer: 3
-  m_SortingOrder: 1
+  m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: d35dbd4324b9ea646b18d5dc81d57e14, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -160,9 +160,11 @@ MonoBehaviour:
   speedMultiplier: 10
   damageMultiplier: 0.5
   cooldownTime: 10
+  owningWispsGroup: {fileID: 0}
   detachedTrailWidth: 1
   attachedTrailWidth: 0.2
   poisonCoolDown: 0.2
+  stackedAngleSpace: 10
 --- !u!96 &4106393977854036229
 TrailRenderer:
   serializedVersion: 3

--- a/Assets/Scripts/Entities/Player/Player.cs
+++ b/Assets/Scripts/Entities/Player/Player.cs
@@ -13,7 +13,6 @@ public class Player : MonoBehaviour
     private Entity _entity;
     private Weapon weapon;
     private bool onlyWeaponAttack = false;
-    public int hitNumber = 0;
 
 
     public WispsGroup wisps { get { return _wisps; } }
@@ -82,12 +81,6 @@ public class Player : MonoBehaviour
     {
         if (invicibleCurrentCoolDown > float.Epsilon)
             return;
-        if (hitNumber > 0)
-        {
-            hitNumber -= 1;
-            invicibleCurrentCoolDown = invicibleCoolDown;
-            return;
-        }
         invicibleCurrentCoolDown = invicibleCoolDown;
         if (!wisps.AbsorbDamage())
             GameManager.Instance.GameOver();

--- a/Assets/Scripts/Entities/Player/Player.cs
+++ b/Assets/Scripts/Entities/Player/Player.cs
@@ -77,6 +77,12 @@ public class Player : MonoBehaviour
             weapon?.Attack();
     }
 
+    public void SecondaryAttack()
+    {
+        if (onlyWeaponAttack || !wisps.ActivateSelectedStack())
+            weapon?.Attack();
+    }
+
     public void TakeDamage()
     {
         if (invicibleCurrentCoolDown > float.Epsilon)

--- a/Assets/Scripts/Entities/Player/Player.cs
+++ b/Assets/Scripts/Entities/Player/Player.cs
@@ -58,12 +58,12 @@ public class Player : MonoBehaviour
 
     public void SelectNextWisp()
     {
-        wisps.SelectNextWisp();
+        wisps.SelectNextStack();
     }
 
     public void SelectPreviousWisp()
     {
-        wisps.SelectPreviousWisp();
+        wisps.SelectPreviousStack();
     }
 
     public void AddWisp(Wisp wisp)
@@ -74,10 +74,7 @@ public class Player : MonoBehaviour
 
     public void Attack()
     {
-        Wisp wisp = wisps.GetSelectedWisp();
-        if (!onlyWeaponAttack && wisp != null && wisp.IsActivable())
-            StartCoroutine(wisp.Activate());
-        else
+        if (onlyWeaponAttack || !wisps.ActivateSelectedWisp())
             weapon?.Attack();
     }
 
@@ -91,14 +88,8 @@ public class Player : MonoBehaviour
             invicibleCurrentCoolDown = invicibleCoolDown;
             return;
         }
-        Wisp wisp = wisps.GetSelectedWisp();
         invicibleCurrentCoolDown = invicibleCoolDown;
-        if (wisp != null)
-        {
-            wisps.DetachWisp(wisp);
-            Destroy(wisp.gameObject);
-        }
-        else
+        if (!wisps.AbsorbDamage())
             GameManager.Instance.GameOver();
     }
 }

--- a/Assets/Scripts/Entities/Player/PlayerController.cs
+++ b/Assets/Scripts/Entities/Player/PlayerController.cs
@@ -20,6 +20,8 @@ public class PlayerController : Singleton<Player>
 
         if (Input.GetButtonDown("Attack"))
             player.Attack();
+        if (Input.GetButtonDown("SecondaryAttack"))
+            player.SecondaryAttack();
         if (Input.GetButtonDown("ToggleWeaponMode"))
             player.ToggleWeaponMode();
         if (Input.GetButtonDown("SelectNextWisp"))

--- a/Assets/Scripts/Entities/Wisps/DefenseWisp.cs
+++ b/Assets/Scripts/Entities/Wisps/DefenseWisp.cs
@@ -4,21 +4,30 @@ using UnityEngine;
 
 public class DefenseWisp : Wisp
 {
+    private bool loaded;
+
     protected override void Awake()
     {
         base.Awake();
+        loaded = true;
         onActivate += OnActivate;
-    }
-
-    private void Start()
-    {
-        owner.hitNumber += 1;
+        _onDamage += OnDamage;
     }
 
     private IEnumerator OnActivate()
     {
-        if (owner.hitNumber == 0)
-            owner.hitNumber += 1;
+        loaded = true;
         yield break;
+    }
+
+    private new bool OnDamage(bool absorbed)
+    {
+        // Damage has not been absorbed and the wisp is loaded
+        if (!absorbed && loaded)
+        {
+            loaded = false;
+            return true;
+        }
+        return false;
     }
 }

--- a/Assets/Scripts/Entities/Wisps/PoisonWisp.cs
+++ b/Assets/Scripts/Entities/Wisps/PoisonWisp.cs
@@ -10,6 +10,7 @@ public class PoisonWisp : Wisp
     public float detachedTrailWidth;
     public float attachedTrailWidth;
     public float poisonCoolDown = 0.5f;
+    public float stackedAngleSpace = 10;
 
     private float poisonCurrentCoolDown = 0.0f;
 
@@ -62,7 +63,10 @@ public class PoisonWisp : Wisp
 
     private IEnumerator OnActivate()
     {
-        SetTarget((Vector2)owner.transform.position + owner.aimedDirection * range);
+        int index = stackInfos.index - stackInfos.size / 2;
+        Vector2 wispDirection = Quaternion.Euler(0f, 0f, index * stackedAngleSpace) * owner.aimedDirection;
+
+        SetTarget((Vector2)owner.transform.position + wispDirection * range);
         while (MoveTowardsTarget() && !Attack())
             yield return null;
     }

--- a/Assets/Scripts/Entities/Wisps/Wisp.cs
+++ b/Assets/Scripts/Entities/Wisps/Wisp.cs
@@ -27,6 +27,13 @@ public abstract class Wisp : MovingObject
     }
     public Color disabledColor;
 
+    protected class StackInformations
+    {
+        public int index;
+        public int size;
+    }
+    protected StackInformations stackInfos = new();
+
 
     public float rangeMultiplier = 1;
     public float range { get { return owner.entity.range * rangeMultiplier; } }
@@ -124,10 +131,12 @@ public abstract class Wisp : MovingObject
         yield return StartCoroutine(eventsProcessor.StartAsyncEvents(onAttach));
     }
 
-    public IEnumerator Activate()
+    public IEnumerator Activate(int stackIndex = 0, int stackSize = 1)
     {
         if (IsActivable())
         {
+            stackInfos.index = stackIndex;
+            stackInfos.size = stackSize;
             // Activate the cooldown
             currentCooldown = cooldownTime / owner.entity.attackSpeed;
             // Detach the wisp from the group

--- a/Assets/Scripts/Entities/Wisps/Wisp.cs
+++ b/Assets/Scripts/Entities/Wisps/Wisp.cs
@@ -43,11 +43,15 @@ public abstract class Wisp : MovingObject
 
     public WispsGroup owningWispsGroup = null;
 
+    public delegate bool OnDamage(bool absorbed);
     protected AsyncEventsProcessor eventsProcessor;
     protected AsyncEventsProcessor.AsyncEvent onDetach;
     protected AsyncEventsProcessor.AsyncEvent onActivate;
     protected AsyncEventsProcessor.AsyncEvent onAttach;
     protected AsyncEventsProcessor.AsyncEvent onDeath;
+    protected OnDamage _onDamage;
+
+    public OnDamage onDamage { get { return _onDamage; } }
 
     // Start is called before the first frame update
     protected override void Awake()

--- a/Assets/Scripts/Entities/Wisps/WispStack.cs
+++ b/Assets/Scripts/Entities/Wisps/WispStack.cs
@@ -14,7 +14,6 @@ public class WispStack : MovingObject
     {
         transform.position = wisp.transform.position;
         wisps.Clear();
-        wisps.Add(wisp);
         _wispsType = wisp.GetType();
         gameObject.name = "WispStack (" + _wispsType + ")";
         return this;
@@ -79,8 +78,17 @@ public class WispStack : MovingObject
         return wisps.Count;
     }
 
+    public bool AbsorbDamage(bool absorbed)
+    {
+        foreach (Wisp wisp in wisps)
+            absorbed = (wisp.onDamage?.Invoke(absorbed) == true) | absorbed;
+        return absorbed;
+    }
+
     protected override float GetSpeed()
     {
+        if (wisps.Count == 0)
+            return 1;
         return wisps[0].speed;
     }
 }

--- a/Assets/Scripts/Entities/Wisps/WispStack.cs
+++ b/Assets/Scripts/Entities/Wisps/WispStack.cs
@@ -51,6 +51,19 @@ public class WispStack : MovingObject
         return true;
     }
 
+    public bool ActivateStack()
+    {
+        List<Wisp> activableWisps = new();
+
+        foreach (Wisp wisp in wisps)
+            if (wisp.IsActivable())
+                activableWisps.Add(wisp);
+
+        for (int i = 0; i < activableWisps.Count; i++)
+            activableWisps[i].owner.StartCoroutine(activableWisps[i].Activate(i, activableWisps.Count));
+        return activableWisps.Count > 0;
+    }
+
     public bool IsActivable()
     {
         foreach (Wisp wisp in wisps)

--- a/Assets/Scripts/Entities/Wisps/WispStack.cs
+++ b/Assets/Scripts/Entities/Wisps/WispStack.cs
@@ -47,7 +47,7 @@ public class WispStack : MovingObject
         Wisp wisp = GetFirstActivable();
         if (wisp == null)
             return false;
-        StartCoroutine(wisp.Activate());
+        wisp.owner.StartCoroutine(wisp.Activate());
         return true;
     }
 

--- a/Assets/Scripts/Entities/Wisps/WispStack.cs
+++ b/Assets/Scripts/Entities/Wisps/WispStack.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WispStack : MovingObject
+{
+    private List<Wisp> wisps = new();
+    private Type _wispsType;
+
+    public Type wispsType { get { return _wispsType; } }
+
+    public WispStack Setup(Wisp wisp)
+    {
+        transform.position = wisp.transform.position;
+        wisps.Clear();
+        wisps.Add(wisp);
+        _wispsType = wisp.GetType();
+        gameObject.name = "WispStack (" + _wispsType + ")";
+        return this;
+    }
+
+    public bool IsWispTypeCompatible(Wisp wisp)
+    {
+        return wisp.GetType() == wispsType;
+    }
+
+    public void AddWisp(Wisp wisp)
+    {
+        if (!IsWispTypeCompatible(wisp))
+            throw new Exception("Invalid wisp type");
+        wisps.Add(wisp);
+        wisp.transform.SetParent(transform);
+        wisp.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
+        // Update size
+    }
+
+    public Wisp GetFirstActivable()
+    {
+        foreach (Wisp wisp in wisps)
+            if (wisp.IsActivable())
+                return wisp;
+        return null;
+    }
+
+    public bool ActivateSingle()
+    {
+        Wisp wisp = GetFirstActivable();
+        if (wisp == null)
+            return false;
+        StartCoroutine(wisp.Activate());
+        return true;
+    }
+
+    public bool IsActivable()
+    {
+        foreach (Wisp wisp in wisps)
+            if (wisp.IsActivable())
+                return true;
+        return false;
+    }
+
+    public void DetachWisp(Wisp wisp)
+    {
+        wisps.Remove(wisp);
+        wisp.transform.SetParent(null);
+    }
+
+    public Wisp PopWisp()
+    {
+        Wisp wisp = wisps[0];
+
+        DetachWisp(wisp);
+        return wisp;
+    }
+
+    public int WispsCount()
+    {
+        return wisps.Count;
+    }
+
+    protected override float GetSpeed()
+    {
+        return wisps[0].speed;
+    }
+}

--- a/Assets/Scripts/Entities/Wisps/WispStack.cs
+++ b/Assets/Scripts/Entities/Wisps/WispStack.cs
@@ -10,6 +10,22 @@ public class WispStack : MovingObject
 
     public Type wispsType { get { return _wispsType; } }
 
+    protected override void Update()
+    {
+        base.Update();
+        int activable = GetFirstActivableIndex();
+
+        if (activable == -1)
+            return;
+        SpriteRenderer renderer = wisps[activable].GetComponent<SpriteRenderer>();
+        if (renderer.sortingOrder != 1)
+        {
+            foreach (Wisp wisp in wisps)
+                wisp.GetComponent<SpriteRenderer>().sortingOrder = 0;
+            renderer.sortingOrder = 1;
+        }
+    }
+
     public WispStack Setup(Wisp wisp)
     {
         transform.position = wisp.transform.position;
@@ -34,12 +50,20 @@ public class WispStack : MovingObject
         // Update size
     }
 
+    private int GetFirstActivableIndex()
+    {
+        for (int i = 0; i < wisps.Count; i++)
+            if (wisps[i].IsActivable())
+                return i;
+        return -1;
+    }
+
     public Wisp GetFirstActivable()
     {
-        foreach (Wisp wisp in wisps)
-            if (wisp.IsActivable())
-                return wisp;
-        return null;
+        int index = GetFirstActivableIndex();
+        if (index == -1)
+            return null;
+        return wisps[index];
     }
 
     public bool ActivateSingle()

--- a/Assets/Scripts/Entities/Wisps/WispStack.cs.meta
+++ b/Assets/Scripts/Entities/Wisps/WispStack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41681c8803390cc41be9964d0da58504
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Entities/Wisps/WispsGroup.cs
+++ b/Assets/Scripts/Entities/Wisps/WispsGroup.cs
@@ -100,7 +100,7 @@ public class WispsGroup : MonoBehaviour
                 return stack;
         if (createIfNotExisting)
         {
-            WispStack newStack = new GameObject("Room", typeof(WispStack)).GetComponent<WispStack>().Setup(wisp);
+            WispStack newStack = new GameObject("WispStack", typeof(WispStack)).GetComponent<WispStack>().Setup(wisp);
             newStack.transform.SetParent(transform);
             InsertStackNaturally(newStack);
             return newStack;

--- a/Assets/Scripts/Entities/Wisps/WispsGroup.cs
+++ b/Assets/Scripts/Entities/Wisps/WispsGroup.cs
@@ -164,9 +164,7 @@ public class WispsGroup : MonoBehaviour
 
     public bool ActivateSelectedStack()
     {
-        if (selectedStack == null || !selectedStack.IsActivable())
-            return false;
-        return false;
+        return selectedStack != null && selectedStack.ActivateStack();
     }
 
     public void SelectNextStack()

--- a/Assets/Scripts/Entities/Wisps/WispsGroup.cs
+++ b/Assets/Scripts/Entities/Wisps/WispsGroup.cs
@@ -207,10 +207,26 @@ public class WispsGroup : MonoBehaviour
         }
     }
 
+    private bool CallWispOnDamage()
+    {
+        if (selectedStack == null)
+            return false;
+        bool absorbed = selectedStack.AbsorbDamage(false);
+
+        foreach (WispStack stack in stacks)
+            absorbed = stack.AbsorbDamage(absorbed) | absorbed;
+        return absorbed;
+    }
+
     public bool AbsorbDamage()
     {
         if (selectedStack == null)
             return false;
+        // Trigger wisps OnDamage (they may absorb the damage)
+        if (CallWispOnDamage())
+            return true;
+
+        // Absorb the damage at a cost of 1 wisp
         Destroy(selectedStack.PopWisp());
         if (selectedStack.WispsCount() == 0)
             DeleteStack(selectedStack);

--- a/Assets/Scripts/Entities/Wisps/WispsGroup.cs
+++ b/Assets/Scripts/Entities/Wisps/WispsGroup.cs
@@ -142,7 +142,7 @@ public class WispsGroup : MonoBehaviour
                 SelectNextStack();
         }
         stacks.Remove(stack);
-        Destroy(stack);
+        Destroy(stack.gameObject);
         EqualizeStacks();
     }
 
@@ -155,7 +155,6 @@ public class WispsGroup : MonoBehaviour
         stack.DetachWisp(wisp);
         if (stack.WispsCount() == 0)
             DeleteStack(stack);
-        wisp.transform.SetParent(null);
     }
 
     public bool ActivateSelectedWisp()
@@ -227,7 +226,7 @@ public class WispsGroup : MonoBehaviour
             return true;
 
         // Absorb the damage at a cost of 1 wisp
-        Destroy(selectedStack.PopWisp());
+        Destroy(selectedStack.PopWisp().gameObject);
         if (selectedStack.WispsCount() == 0)
             DeleteStack(selectedStack);
         return true;


### PR DESCRIPTION
# Description

Introduce new wisp stack functionnality. Now wisps are stacked based on their types. When the player attack, he can use a single wisp from the stack or the whole stack.

Refactored the wisp event system using delegates.

Close #82

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Minor fixes

Refactored defense wisp using new delegate system (Wisp.onDamage)
Fixed bomb wisp.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
