### PR TITLE
Fix enemy not loading when loading gamescene from menu

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -12,7 +12,7 @@ public class GameManager : Singleton<GameManager>
 
     void Start()
     {
-        InitGame();
+        Invoke("InitGame", 0.1f);
     }
 
     void Update()

--- a/Assets/Scripts/Generation/Room.cs
+++ b/Assets/Scripts/Generation/Room.cs
@@ -41,6 +41,7 @@ public class Room : MonoBehaviour
     public List<Vector2> roomBoundaries;
 
     // Associative double dimension array representing the cells
+    private GameObject tiles;
     private List<List<Cell>> grid;
 
     public Vector2Int RoomToGrid(Vector2 roomPos)
@@ -150,18 +151,21 @@ public class Room : MonoBehaviour
             {
                 Cell cell = grid[x][y];
                 Vector2 pos = GridToRoom(new Vector2Int(x, y));
+                GameObject prefab = null;
                 switch (cell.type)
                 {
                     case CellType.Floor:
-                        cell.gameObject = Instantiate(PrefabManager.GetRandomFloor(), pos, Quaternion.identity, transform);
+                        prefab = PrefabManager.GetRandomFloor();
                         break;
                     case CellType.Wall:
-                        cell.gameObject = Instantiate(PrefabManager.GetRandomWall(), pos, Quaternion.identity, transform);
+                        prefab = PrefabManager.GetRandomWall();
                         break;
                     case CellType.Border:
-                        cell.gameObject = Instantiate(PrefabManager.GetRandomOuterWall(), pos, Quaternion.identity, transform);
+                        prefab = PrefabManager.GetRandomOuterWall();
                         break;
                 }
+                if (prefab != null)
+                    cell.gameObject = Instantiate(prefab, pos, Quaternion.identity, tiles.transform);
             }
         }
 
@@ -172,6 +176,9 @@ public class Room : MonoBehaviour
 
     public void Initialize(Vector2 partSize, List<Vector2> partsPositions)
     {
+        tiles = new GameObject("Tiles");
+        tiles.transform.SetParent(transform);
+
         this._partSize = partSize;
         this._partsPositions = partsPositions;
 

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -13,7 +13,7 @@ public class MainMenu : MonoBehaviour
 
     public void PlayGame()
     {
-        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
+        SceneManager.LoadScene("GameScene");
     }
 
     public void QuitGame()


### PR DESCRIPTION
# Description

Delay the init game to fix entity loading. Don't know why this work but it does. A loading screen should be set later.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Minor fixes

Also refactored tiles object instantiating in room.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
